### PR TITLE
CMake: Renamed project to just 'kissnet'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
 set(CMAKE_CXX_STANDARD 17)
 
-project(kissnet_ci)
+project(kissnet)
 
 include_directories (.)
 
-add_executable(output ./kissnet.cpp)
+add_library(kissnet STATIC ./kissnet.cpp)


### PR DESCRIPTION
[edit] I'd like to use kissnet as a submodule (library target), but the included CMake is apparently only made to create an executable target for AppVeyor.

Work in progress.