### PR TITLE
Eliminate memcpy() for TCP and fix lengths for connect() calls

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,9 +28,9 @@ foreach t : ['tcp_echo_server']
 endforeach
 
 dir = 'tests/'
-foreach t : ['acceptor', 'endpoint', 'error_handler', 'loopback_udp', 'simple']
+foreach t : ['acceptor', 'endpoint', 'error_handler', 'loopback_tcp', 'loopback_udp', 'simple']
   exe = executable(t, dir + t + '/main.cpp', dependencies: winlibs)
-  if ['endpoint', 'error_handler', 'loopback_udp', 'simple'].contains(t)
+  if ['endpoint', 'error_handler', 'loopback_tcp', 'loopback_udp', 'simple'].contains(t)
     test(t, exe, timeout : 5)
   endif
 endforeach

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   string(APPEND CMAKE_CXX_FLAGS " -Wall -Wno-long-long -pedantic")
 endif()
 
-foreach(d acceptor endpoint error_handler loopback_udp simple socket)
+foreach(d acceptor endpoint error_handler loopback_tcp loopback_udp simple socket)
   add_subdirectory(${d})
 endforeach()
 
@@ -19,12 +19,12 @@ if(WIN32)
 set(WINSOCK_LIBRARIES wsock32 ws2_32 Iphlpapi)
 endif()
 
-foreach(t acceptor_test endpoint_test error_handler_test loopback_udp_test simple_test socket_test)
+foreach(t acceptor_test endpoint_test error_handler_test loopback_tcp_test loopback_udp_test simple_test socket_test)
   set_target_properties(${t} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
   target_link_libraries(${t} PRIVATE kissnet ${WINSOCK_LIBRARIES})
 endforeach()
 
-foreach(t endpoint_test error_handler_test loopback_udp_test simple_test)
+foreach(t endpoint_test error_handler_test loopback_tcp_test loopback_udp_test simple_test)
   add_test(NAME test:${t} COMMAND $<TARGET_FILE:${t}>)
   set_tests_properties(test:${t} PROPERTIES TIMEOUT 5)
 endforeach()

--- a/tests/acceptor/main.cpp
+++ b/tests/acceptor/main.cpp
@@ -1,12 +1,12 @@
-#include <kissnet.hpp>
 #include <iostream>
 
+#include <kissnet.hpp>
 namespace kn = kissnet;
 
-int main()
+void acceptor(const std::string address)
 {
 	//setup socket
-	kn::tcp_socket server(kn::endpoint("0.0.0.0:8080"));
+	kn::tcp_socket server(kn::endpoint(address, 8080));
 	server.bind();
 	server.listen();
 
@@ -20,6 +20,13 @@ int main()
 	//Add null terminator, and print as string
 	if(size < buff.size()) buff[size] = std::byte{ 0 };
 	std::cout << reinterpret_cast<const char*>(buff.data()) << '\n';
+}
 
+int main()
+{
+	acceptor("0.0.0.0");
+	acceptor("::");
+	
+	//So long, and thanks for all the fish
 	return 0;
 }

--- a/tests/loopback_tcp/CMakeLists.txt
+++ b/tests/loopback_tcp/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(loopback_tcp_test main.cpp)
+find_package(Threads)
+if(Threads_FOUND)
+target_link_libraries(loopback_tcp_test PRIVATE Threads::Threads)
+endif()

--- a/tests/loopback_tcp/main.cpp
+++ b/tests/loopback_tcp/main.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <thread>
+#include <chrono>
+
+#include <kissnet.hpp>
+using namespace std::chrono_literals;
+namespace kn = kissnet;
+
+void loopback_tcp(const std::string listen_address, const std::string connect_address, const int port)
+{
+    std::thread listen_th([&] {
+		kn::tcp_socket listener(kn::endpoint(listen_address, port));
+		listener.set_non_blocking();
+		listener.bind();
+		listener.listen();
+
+		const char* hello_goodbye			= "Hello hello, I don't know why you say goodbye, I say hello!";
+		const size_t hello_goodbye_size		= strlen(hello_goodbye);
+		const std::byte* hello_goodbye_byte = reinterpret_cast<const std::byte*>(hello_goodbye);
+
+		for(size_t i = 0; i < 50; ++i)
+		{
+			std::this_thread::sleep_for(100ms);
+			if(auto socket = listener.accept(); socket.is_valid())
+			{
+				std::cout << "Accepted connect\n";
+				socket.send(hello_goodbye_byte, hello_goodbye_size);
+			}
+			else
+			{
+				std::cout << "No connections to accept...\n";
+			}
+		}
+		listener.close();
+	});
+	
+	listen_th.detach();
+	
+	std::this_thread::sleep_for(200ms);
+	kn::tcp_socket a_socket(kn::endpoint(connect_address, port));
+	
+	a_socket.connect();
+	
+	//Receive data into a buffer
+	kn::buffer<4096> static_buffer;
+
+	//Get the data, and the lengh of data
+	const auto [data_size, socket_status] = a_socket.recv(static_buffer);
+	a_socket.close();
+
+	//To print it as a good old C string, add a null terminator
+	if(data_size < static_buffer.size())
+		static_buffer[data_size] = std::byte { '\0' };
+
+	//Print the raw data as text into the terminal (should display html/css code here)
+	std::cout << reinterpret_cast<const char*>(static_buffer.data()) << '\n';
+}
+
+int main()
+{
+	// Increment port number to avoid bind failure on TIME-WAIT connections
+	loopback_tcp("0.0.0.0", "127.0.0.1", 6666);
+	loopback_tcp("::", "::1", 6667);
+	
+	return EXIT_SUCCESS;
+}

--- a/tests/loopback_udp/main.cpp
+++ b/tests/loopback_udp/main.cpp
@@ -4,45 +4,52 @@
 #include <kissnet.hpp>
 namespace kn = kissnet;
 
-int main()
+void loopback_udp(const std::string send_address, const std::string recv_address)
 {
-//Socket used to send, the "endpoint" is the destination of the data
-kn::udp_socket a_socket(kn::endpoint("127.0.0.1", 6666));
+	//Socket used to send, the "endpoint" is the destination of the data
+	kn::udp_socket a_socket(kn::endpoint(send_address, 6666));
 
-//Socket used to receive, the "endpoint" is where to listen to data
-kn::udp_socket b_socket(kn::endpoint("0.0.0.0", 6666));
-b_socket.bind();
+	//Socket used to receive, the "endpoint" is where to listen to data
+	kn::udp_socket b_socket(kn::endpoint(recv_address, 6666));
+	b_socket.bind();
 
-//Byte buffer
-kn::buffer<16> buff;
+	//Byte buffer
+	kn::buffer<16> buff;
 
-//Build data to send (flat array of bytes
-for(unsigned char i = 0; i < 16; i++)
-  buff[i] = std::byte{ i };
+	//Build data to send (flat array of bytes
+	for(unsigned char i = 0; i < 16; i++)
+		buff[i] = std::byte{ i };
 
-//Send data
-a_socket.send(buff.data(), 16);
+	//Send data
+	a_socket.send(buff.data(), 16);
 
-//We do know, for the sake of the example, that there are 16 bytes to get from the network
-kn::buffer<16> recv_buff;
+	//We do know, for the sake of the example, that there are 16 bytes to get from the network
+	kn::buffer<16> recv_buff;
 
-//Actually print bytes_available
-std::cout << "avaliable in UDP socket : " << b_socket.bytes_available() << " bytes\n";
+	//Actually print bytes_available
+	std::cout << "avaliable in UDP socket : " << b_socket.bytes_available() << " bytes\n";
 
-//You receive in the same way
-auto [received_bytes, status] = b_socket.recv(recv_buff);
-const auto from = b_socket.get_recv_endpoint();
+	//You receive in the same way
+	auto [received_bytes, status] = b_socket.recv(recv_buff);
+	const auto from = b_socket.get_recv_endpoint();
 
-//Print the data
-std::cout << "Received: ";
+	//Print the data
+	std::cout << "Received: ";
 
-for(unsigned char i = 0; i < 16; i++)
-{
-  std::cout << std::hex << std::to_integer<int>(recv_buff[i]) << std::dec << ' ';
+	for(unsigned char i = 0; i < 16; i++)
+	{
+		std::cout << std::hex << std::to_integer<int>(recv_buff[i]) << std::dec << ' ';
+	}
+
+	//Print who send the data
+	std::cout << "From: " << from.address << ' ' << from.port << '\n';
 }
 
-//Print who send the data
-std::cout << "From: " << from.address << ' ' << from.port << '\n';
-
-return EXIT_SUCCESS;
+int main()
+{
+	loopback_udp("127.0.0.1", "0.0.0.0");
+	loopback_udp("::1", "::");
+	
+	//So long, and thanks for all the fish
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The memcpy() calls and socket_output seem to be unnecessary, since
getaddrinfo_results->ai_addr can be passed directly to syscall_connect.
Also, use socklen_t(getaddrinfo_results->ai_addrlen) for the length,
since IPv6 ai_addrs are longer than sizeof(SOCKADDR) (at least on
Windows and Linux).

I'm not an expert at low-level socket programming, but all the research I have done indicates this should be the correct way to do it.  Copying into socket_output using getaddrinfo_results->ai_addrlen shouldn't be an issue because socket_output is a sockaddr_storage, which should be defined by the OS to be large enough to fit any type of sockaddr struct.  If I'm wrong, please let me know and I will correct it however necessary.

This fixes https://github.com/kodi-pvr/pvr.hts/issues/483 (again).