### PR TITLE
ci should also trigger on *.hpp change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: ci
 on:
   push:
     paths:
-      - "**/*.cpp"
-      - "**/*.cmake"
+      - "**.cpp"
+      - "**.hpp"
+      - "**.cmake"
       - "**/CMakeLists.txt"
       - ".github/workflows/ci.yml"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,5 +52,5 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 endif()
 
 include(FeatureSummary)
-add_feature_info(Tests build_tests "kissnet examples and tests")
+add_feature_info(Tests kissnet_BUILD_TESTING "kissnet examples and tests")
 feature_summary(WHAT ALL)


### PR DESCRIPTION
As kissnet is a header-only library, the CI should be triggering
on .hpp changes too.