### PR TITLE
update deprecated TLS method

### DIFF
--- a/kissnet.hpp
+++ b/kissnet.hpp
@@ -936,7 +936,7 @@ namespace kissnet
 					return socket_status::errored;
 				}
 
-				auto* pMethod = TLSv1_2_client_method();
+				auto* pMethod = TLS_client_method();
 
 				pContext = SSL_CTX_new(pMethod);
 				pSSL = SSL_new(pContext);


### PR DESCRIPTION
OpenSSL docs
https://www.openssl.org/docs/man1.1.1/man3/TLSv1_2_client_method.html
note that the prior method is deprecated, and recommend this method.
g++10 compiler was emitting deprecating warning before this change.