### PR TITLE
CI: fix quirks, add clang test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     - run: brew install openssl
 
-    - run: cmake -B build -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -Dkissnet_BUILD_TESTING:BOOL=on
+    - run: cmake -B build -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/ -Dkissnet_BUILD_TESTING:BOOL=on
       env:
         CXX: g++-9
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,29 @@ jobs:
       working-directory: build
 
 
-  mac:
+  mac_gcc:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
 
-    - run: brew install openssl
-
     - run: cmake -B build -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/ -Dkissnet_BUILD_TESTING:BOOL=on
       env:
         CXX: g++-9
+
+    - run: cmake --build build --parallel
+
+    - run: ctest --output-on-failure
+      working-directory: build
+
+
+  mac_clang:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - run: cmake -B build -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/ -Dkissnet_BUILD_TESTING:BOOL=on
+      env:
+        CXX: clang++
 
     - run: cmake --build build --parallel
 
@@ -57,6 +70,7 @@ jobs:
 
       - run: ctest --output-on-failure
         working-directory: build
+
 
   msvc:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ on:
       - "**.cmake"
       - "**/CMakeLists.txt"
       - ".github/workflows/ci.yml"
-
+  pull_request:
+    paths:
+      - "**.cpp"
+      - "**.hpp"
+      - "**.cmake"
+      - "**/CMakeLists.txt"
+      - ".github/workflows/ci.yml"
 
 jobs:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ option(kissnet_BUILD_TESTING "build test programs")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
+set(CI $ENV{CI})  # we'll use this to omit CI-shaky tests
+
 add_library(kissnet INTERFACE)
 add_library(kissnet::kissnet ALIAS kissnet)
 target_compile_features(kissnet INTERFACE cxx_std_17)

--- a/tests/socket/CMakeLists.txt
+++ b/tests/socket/CMakeLists.txt
@@ -4,6 +4,8 @@ if(Threads_FOUND)
 target_link_libraries(socket_test PRIVATE Threads::Threads)
 endif()
 
+if(NOT CI)
+# this test can be shaky on CI, and for example if the website server is down the CI won't know that
 add_test(NAME test:socket:ipv4
 COMMAND $<TARGET_FILE:socket_test> 127.0.0.1 0.0.0.0)
 set_tests_properties(test:socket:ipv4 PROPERTIES TIMEOUT 30 RESOURCE_LOCK port)
@@ -11,3 +13,4 @@ set_tests_properties(test:socket:ipv4 PROPERTIES TIMEOUT 30 RESOURCE_LOCK port)
 add_test(NAME test:socket:ipv6
 COMMAND $<TARGET_FILE:socket_test> ::1 ::)
 set_tests_properties(test:socket:ipv6 PROPERTIES TIMEOUT 30 RESOURCE_LOCK port)
+endif()


### PR DESCRIPTION
fixes #34

* Socket test that was just added may be too shaky for CI (what if test website down), also I've seen sometimes CI network security interferes with some tests like this in general.
* MacOS: recommended to use version-specific OpenSSL hint on CI, as often multiple versions are installed
* add workflow for Clang as well as GCC

Sorry for not catching those before merge. Before other recent PRs were merged, the CI was not triggering properly but now it is.