### PR TITLE
Socket option SO_REUSEADDR

### DIFF
--- a/kissnet.hpp
+++ b/kissnet.hpp
@@ -922,6 +922,15 @@ namespace kissnet
 				kissnet_fatal_error("setting socket to nonblock returned an error");
 		}
 
+		///Set the socket option for reuse addr
+		/// \param state By default "false". If put to false, it will disable reuseaddr
+		void set_reuseaddr(bool state = false) const
+		{
+			const int reuse = state ? 1 : 0;
+			if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuse), sizeof(reuse)) != 0)
+				kissnet_fatal_error("setting socket broadcast mode returned an error");
+		}
+
 		///Set the socket option for broadcasts
 		/// \param state By default "true". If put to false, it will disable broadcasts
 		void set_broadcast(bool state = true) const


### PR DESCRIPTION
I added the function `set_reuseaddr` because I needed it in one of my projects. Maybe it would be good to merge it.