### PR TITLE
#73 Only use AI_ADDRCONFIG if not connecting to loopback

### DIFF
--- a/kissnet.hpp
+++ b/kissnet.hpp
@@ -879,7 +879,15 @@ namespace kissnet
 			//Do we use streams or datagrams
 			initialize_addrinfo();
 
-			if (getaddrinfo(bind_loc.address.c_str(), std::to_string(bind_loc.port).c_str(), &getaddrinfo_hints, &getaddrinfo_results) != 0)
+			// Don't use AI_ADDRCONFIG if connecting to loopback
+			// See https://fedoraproject.org/wiki/QA/Networking/NameResolution/ADDRCONFIG
+			const std::string addr = bind_loc.address;
+			if (
+				addr == "localhost" || addr == "localhost.localdomain" || addr == "localhost6" || addr == "localhost6.localdomain6" || addr == "127.0.0.1" || addr == "::1")
+			{
+				getaddrinfo_hints.ai_flags = 0;
+			}
+			if (getaddrinfo(addr.c_str(), std::to_string(bind_loc.port).c_str(), &getaddrinfo_hints, &getaddrinfo_results) != 0)
 			{
 				kissnet_fatal_error("getaddrinfo failed!");
 			}

--- a/kissnet.hpp
+++ b/kissnet.hpp
@@ -882,8 +882,7 @@ namespace kissnet
 			// Don't use AI_ADDRCONFIG if connecting to loopback
 			// See https://fedoraproject.org/wiki/QA/Networking/NameResolution/ADDRCONFIG
 			const std::string addr = bind_loc.address;
-			if (
-				addr == "localhost" || addr == "localhost.localdomain" || addr == "localhost6" || addr == "localhost6.localdomain6" || addr == "127.0.0.1" || addr == "::1")
+			if (addr == "localhost" || addr == "localhost.localdomain" || addr == "localhost6" || addr == "localhost6.localdomain6" || addr == "127.0.0.1" || addr == "::1")
 			{
 				getaddrinfo_hints.ai_flags = 0;
 			}


### PR DESCRIPTION
Fix for issue #73 

I don't think this is a perfect fix! This is close to Mozilla's fix (https://hg.mozilla.org/releases/mozilla-1.9.2/rev/c5d74bcd7421), except I have also added 127.0.0.1 and ::1. (Note that technically there are more loopback addresses; with this fix 127.0.0.2 still won't work.) 

I've looked into a couple of other projects' solutions to this:
https://searchfox.org/mozilla-central/source/nsprpub/pr/src/misc/prnetdb.c
http://svn.apache.org/viewvc/apr/apr/trunk/network_io/unix/sockaddr.c?view=markup

... and there are a couple of things worth noting:
1. We could consider adding an ifdef around the use of AI_ADDRCONFIG in general - it acts in some really surprising ways! Users who do not want the feature can then compile without it. Of course, this might cause some issues with how kissnet currently supports IPv6 (since I think that relies on it?), so that seems like a more complicated fix.
2. They both have a retry step if getaddrinfo fails with AI_ADDRCONFIG. I haven't added it here since it wasn't necessary to fix the bug on my end, but that would work too. I'd be happy to include that too if you think it's necessary.

I guess what I'm trying to say is that AI_ADDRCONFIG is a bit of a mess and it might be worth considering a bigger fix. I think it mostly works for this project, and this fix should circumvent the biggest issue with it, so it's probably fine, but there may be other bugs lurking here. 